### PR TITLE
DTSW-7218-Write-up-clear-instructions-on-how-to-upgrade-dt-shell-from-daffy-to-ente

### DIFF
--- a/src/10-setup/02-software/duckietown-shell-dts-installation.md
+++ b/src/10-setup/02-software/duckietown-shell-dts-installation.md
@@ -18,6 +18,14 @@ This section describes how to install and set up `DTS` (`Duckietown Shell`), a C
 
 ## `dts` Installation
 
+````{attention}
+If you have already installed `dts` using `pip3`, run the following command and follow the on-screen instructions:
+
+```shell
+pip3 uninstall duckietown-shell
+```
+````
+
 To install `dts`, run:
 
 ```shell

--- a/src/10-setup/02-software/duckietown-shell-dts-installation.md
+++ b/src/10-setup/02-software/duckietown-shell-dts-installation.md
@@ -72,14 +72,6 @@ dts :  Correctly identified as uid = UID
 ```
 ````
 
-````{note}
-To switch your `DTS` profile from `daffy` to `ente`, run:
-
-```shell
-dts profile switch ente
-```
-````
-
 You can change the token/login as a different user with:
 
     dts tok set
@@ -88,7 +80,29 @@ and verify it with:
 
     dts tok status
 
+(dt-account-switch-profile)=
+### Switch to a different `dts` profile
 
+To get a list of the available `dts` profiles, run:
+
+```shell
+dts profile list
+```
+
+To create a new `dts` profile:
+
+1. Run `dts profile new`.
+2. Select the name of the profile to create using <kbd>UpArrow</kbd> and <kbd>DownArrow</kbd>.
+3. Press <kbd>Enter</kbd>.
+4. Copy your [Duckietown Token](https://hub.duckietown.com/token).
+5. Paste your Duckietown Token into the terminal.
+6. Press <kbd>Enter</kbd>.
+
+To switch to a different `dts` profile, run the following command, where `PROFILE` is the name of the profile:
+
+```shell
+dts profile switch PROFILE
+```
 
 (dt-account-dockerhub-config-docker-set)=
 ### Configure Docker in the Duckietown Shell

--- a/src/welcome-to-the-duckietown-manual.md
+++ b/src/welcome-to-the-duckietown-manual.md
@@ -23,6 +23,10 @@ version of the documentation please see the [daffy version](https://docs.duckiet
 
 If you are a Duckietown veteran, treat this book as a reference manual on how to do specific things. 
 
+```{attention}
+If you are switching from `daffy` to `ente`, you may want to start [here](dt-account-switch-profile).
+```
+
 If you have suggestions on how to improve this documentation, 
 read the [](book-devmanual-intro) section to learn how to make contributions.
 

--- a/src/welcome-to-the-duckietown-manual.md
+++ b/src/welcome-to-the-duckietown-manual.md
@@ -18,24 +18,23 @@ If you are new to Duckietown, you should find a course that helps you navigate t
 
 ```{note}
 This manual is entended to be paired with the `ente` version of Duckietown (and beyond). For the previous
-version of the documentation please see the [daffy version](https://docs.duckietown.com/daffy).
+version of the documentation, see the [daffy version Duckietown documentation](https://docs.duckietown.com/daffy).
 ```
 
-If you are a Duckietown veteran, treat this book as a reference manual on how to do specific things. 
+If you are a Duckietown veteran, you can use this book as a reference manual for specific tasks. 
 
 ```{attention}
-If you are switching from `daffy` to `ente`, you may want to start [here](dt-account-switch-profile).
+If you are switching from `daffy` to `ente`, check out [](dt-account-switch-profile).
 ```
 
-If you have suggestions on how to improve this documentation, 
-read the [](book-devmanual-intro) section to learn how to make contributions.
+If you have suggestions on how to improve this documentation, read the [](book-devmanual-intro) section to learn how to make contributions.
 
 (how-to-get-help-pointer)=
 ## How to Get Help
 
 Read the [FAQ and Troubleshooting](how-to-get-help) to find out how to get support in Duckietown.
 
-This book is structured in 3 main parts:
+This book is structured into 3 main parts:
 
 1. The first part is about how to build and use the robots, including running the demos and learning experiences.
 2. The second part is about going further and using this platform to do more advanced things that you build.


### PR DESCRIPTION
This pull request improves the installation and setup documentation for the Duckietown Shell (`dts`) by clarifying instructions, reorganizing profile management guidance, and enhancing visibility for users switching between Duckietown versions. The most important changes are grouped below.

### Installation and Uninstallation Guidance

* Added an attention block instructing users who previously installed `dts` via `pip3` to uninstall it before proceeding, to avoid conflicts.

### Profile Management Instructions

* Removed the previous note about switching profiles and replaced it with a detailed section explaining how to list, create, and switch `dts` profiles, including step-by-step instructions and keyboard navigation tips. [[1]](diffhunk://#diff-567f7b868d4b9da6401ee035d2c9be2fc1c329790128b9896142c01e7df1b0e6L67-L74) [[2]](diffhunk://#diff-567f7b868d4b9da6401ee035d2c9be2fc1c329790128b9896142c01e7df1b0e6R83-R105)

### Version Switching Visibility

* Added an attention block to the welcome manual, directing users switching from `daffy` to `ente` to the new profile switching instructions for easier onboarding.