### PR TITLE
add devcontainer beta instructions to table of content

### DIFF
--- a/src/_toc.yml
+++ b/src/_toc.yml
@@ -24,6 +24,8 @@ parts:
                             -   file: 10-setup/02-software/docker-installation
                             -   file: 10-setup/02-software/github-installation
                             -   file: 10-setup/02-software/duckietown-shell-dts-installation
+                            -   file: 10-setup/setup-devcontainer.md
+
                     -   file: 50-duckiematrix/introduction-to-the-duckiematrix-virtual-environment
                         sections:
                             - file: 50-duckiematrix/getting-started/duckiematrix-first-steps


### PR DESCRIPTION
This pull request makes a minor update to the table of contents configuration by adding a new setup guide for the development container. No other changes were made.

* Added `10-setup/setup-devcontainer.md` to the `src/_toc.yml` file to include the devcontainer setup guide in the documentation structure.