### PR TITLE
Fix url typo in lx

### DIFF
--- a/src/60-learning-experiences/lx-setup-modeling-kinematics.md
+++ b/src/60-learning-experiences/lx-setup-modeling-kinematics.md
@@ -45,7 +45,7 @@ If you are running Duckietown inside a devcontainer and not on a native Ubuntu s
 
 ### 1. Create a fork 
 
-Navigate to [the Modeling and Kinematics LX repository](https://github.com/duckietown/lx-kinematics-odometryol).
+Navigate to [the Modeling and Kinematics LX repository](https://github.com/duckietown/lx-kinematics-odometry).
 
 Find and press the "Fork" button on the top right:
 


### PR DESCRIPTION
Update lx Github link in lx-setup-modeling-kinematics.md

I am accidentally adding a character at the end of the file, perhaps a newline character? Please remove that change.