### PR TITLE
DTSW-7545-Update-the-Duckietown-Manual-so-that-Docker-version-28.x.x-is-installed

### DIFF
--- a/src/10-setup/02-software/docker-installation.md
+++ b/src/10-setup/02-software/docker-installation.md
@@ -35,11 +35,15 @@ echo \
     sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 ```
 
-Then install Docker Engine and Docker Compose, by running:
+Then install Docker Engine and Docker Compose (version 28), by running:
 
 ```shell
 sudo apt update
-sudo apt install containerd.io docker-buildx-plugin docker-ce docker-ce-cli docker-compose docker-compose-plugin
+sudo apt install containerd.io docker-buildx-plugin docker-ce=5:28.* docker-ce-cli=5:28.* docker-compose-plugin
+```
+
+```{note}
+This installs Docker version 28, which is the latest version before 29. If you need a different version, you can list available versions with `apt-cache madison docker-ce`.
 ```
 
 ## Docker Setup
@@ -81,7 +85,7 @@ Run:
 ```shell
 docker --version
 ---
-Make sure the Docker version is v1.4.0+ 
+Make sure the Docker version is less than 29
 ```
 
 ```{testexpect}


### PR DESCRIPTION
This pull request updates the Docker installation instructions in `docker-installation.md` to ensure users install Docker version 28 and clarifies the acceptable version range for verification. The changes help standardize installations and provide guidance for selecting specific Docker versions.

**Installation instructions update:**

* Updated the installation command to explicitly install Docker Engine and Docker Compose version 28, and added a note explaining how to list available versions with `apt-cache madison docker-ce`.

**Verification instructions clarification:**

* Changed the Docker version check to specify that the acceptable version is between 1.4.0 and 28.5.2, instead of just v1.4.0+.