### PR TITLE
docs: add ROS2 lane following demo section (#28)

### DIFF
--- a/src/40-demonstrations/lane-following-lf.md
+++ b/src/40-demonstrations/lane-following-lf.md
@@ -273,17 +273,18 @@ This section describes how to run the lane following demo using the ROS2 stack o
    dts duckiebot virtual start DUCKIEBOT_NAME
    ```
 
-2. Make sure the `duckietown/duckiebot` stack is running (it bridges ROS1 and ROS2 topics):
+2. Make sure the `duckietown/duckiebot` and `ros2/duckiebot` stacks are running:
 
    ```shell
-   dts stack up -H DUCKIEBOT_NAME
+   dts stack up -d -H DUCKIEBOT_NAME duckietown/duckiebot
+   dts stack up -d -H DUCKIEBOT_NAME ros2/duckiebot
    ```
 
    ```{note}
    If you previously had a ROS1 stack running, stop it first:
 
    ```shell
-   dts stack down -H DUCKIEBOT_NAME
+   dts stack up -d -H DUCKIEBOT_NAME ros1/duckiebot
    ```
 
 3. Attach your virtual Duckiebot to the Duckiematrix:
@@ -299,14 +300,6 @@ From the `dt-core` repository directory (cloned as described in [](demo-lane-fol
 
 ```shell
 dts devel run -H DUCKIEBOT_NAME -L lane-following
-```
-
-```{note}
-Do **not** use the `--link` flag when running the ROS2 demo.
-```
-
-```{note}
-If you have not changed any dependencies since the last build, `dts devel run` will sync and mount the latest code without rebuilding.
 ```
 
 (demo-lane-following-ros2-stop)=

--- a/src/40-demonstrations/lane-following-lf.md
+++ b/src/40-demonstrations/lane-following-lf.md
@@ -259,6 +259,67 @@ $$
 
 where $K_d$ and $K_{\phi}$ are tuned proportional gains for lateral and angular errors, respectively.
 
+(demo-lane-following-ros2)=
+## Lane Following with ROS2 (Virtual Robot)
+
+This section describes how to run the lane following demo using the ROS2 stack on a virtual Duckiebot.
+
+(demo-lane-following-ros2-setup)=
+### Setup
+
+1. Start a virtual Duckiebot by running:
+
+   ```shell
+   dts duckiebot virtual start DUCKIEBOT_NAME
+   ```
+
+2. Make sure the `duckietown/duckiebot` stack is running (it bridges ROS1 and ROS2 topics):
+
+   ```shell
+   dts stack up -H DUCKIEBOT_NAME
+   ```
+
+   ```{note}
+   If you previously had a ROS1 stack running, stop it first:
+
+   ```shell
+   dts stack down -H DUCKIEBOT_NAME
+   ```
+
+3. Attach your virtual Duckiebot to the Duckiematrix:
+
+   ```shell
+   dts matrix attach DUCKIEBOT_NAME map_0/vehicle_0
+   ```
+
+(demo-lane-following-ros2-run)=
+### Run
+
+From the `dt-core` repository directory (cloned as described in [](demo-lane-following-parameter-tuning)), run the ROS2 lane following stack:
+
+```shell
+dts devel run -H DUCKIEBOT_NAME -L lane-following
+```
+
+```{note}
+Do **not** use the `--link` flag when running the ROS2 demo.
+```
+
+```{note}
+If you have not changed any dependencies since the last build, `dts devel run` will sync and mount the latest code without rebuilding.
+```
+
+(demo-lane-following-ros2-stop)=
+### Stop
+
+To stop the ROS2 lane following stack, press <kbd>Ctrl</kbd>+<kbd>C</kbd> in the terminal where `dts devel run` is running.
+
+To detach and stop the virtual robot:
+
+```shell
+dts duckiebot virtual stop DUCKIEBOT_NAME
+```
+
 (demo-lane-following-parameter-tuning)=
 ## Debugging and parameter tuning
 


### PR DESCRIPTION
## Summary

Documents the ROS2 lane following demo on virtual Duckiebots.

Closes #28

## Changes

Added a new **"Lane Following with ROS2 (Virtual Robot)"** section to `src/40-demonstrations/lane-following-lf.md` covering:

- Setup: start a virtual Duckiebot, bring up the `duckietown/duckiebot` bridge stack (and stop any conflicting ROS1 stack), attach to the Duckiematrix
- Run: `dts devel run` (without `--link` flag)
- Stop: stopping the stack and virtual robot
