### PR TITLE
DTSW-7970-Update-sandbox_drone-map

### DIFF
--- a/src/25-duckiedrone/demos/duckiedrone-takeoff-ros2.md
+++ b/src/25-duckiedrone/demos/duckiedrone-takeoff-ros2.md
@@ -53,7 +53,7 @@ To set up the demo:
 5. Attach the Duckiedrone to the matrix engine:
 
     ```shell
-    dts matrix attach ROBOT_NAME map_0/vehicle_1
+    dts matrix attach ROBOT_NAME map_0/vehicle_0
     ```
 
 ```{attention}


### PR DESCRIPTION
This pull request updates the setup instructions for the Duckiedrone takeoff demo. The main change corrects the vehicle identifier used when attaching the Duckiedrone to the matrix engine.

Documentation update:

* Updated the setup command in `duckiedrone-takeoff-ros2.md` to use `map_0/vehicle_0` instead of `map_0/vehicle_1` when attaching the Duckiedrone, ensuring accurate instructions for users.